### PR TITLE
Add dependency of gtk2

### DIFF
--- a/libnotify.nimble
+++ b/libnotify.nimble
@@ -6,4 +6,4 @@ description   = "Minimalistic libnotify wrapper."
 license       = "LGPLv3"
 
 [Deps]
-Requires: "nim >= 0.12"
+Requires: "nim >= 0.12", "gtk2 >= 1.3"


### PR DESCRIPTION
Fixes https://github.com/FedericoCeratto/nim-libnotify/issues/1 if the user doesn't have the `gtk2` pkg installed.